### PR TITLE
Remove rietveld column and add last week commits in the Authors page

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -52,6 +52,7 @@ en:
   deletions: Lines deleted
   first_commit: First commit
   last_commit: Last commit
+  last_week_commits: Last week commits
   author: Author
   show_more: More
   close: Close
@@ -63,5 +64,4 @@ en:
   deletions_by_date: Lines deleted by date
   changed_lines_by_date: Changed lines by date
   gerrit: Chromium Gerrit
-  rietveld: Chromium Rietveld
   ongoing_review: Ongoing Review

--- a/templates/authors/_authors.haml
+++ b/templates/authors/_authors.haml
@@ -16,8 +16,8 @@
             %th #
             %th= :author.t
             %th= :commits.t
+            %th= :last_week_commits.t
             %th= :gerrit.t
-            %th= :rietveld.t
             %th= :ongoing_review.t
             %th= :first_commit.t
             %th= :last_commit.t
@@ -28,8 +28,8 @@
               %th= i+1
               %th= "#{author.name} &lt;#{author.email}&gt;"
               %td= "<a href=https://chromium.googlesource.com/chromium/src/+log/master?author=#{author.email}>#{author.commits.size}</a>"
+              %td= "<a href=https://chromium-review.googlesource.com/q/(owner:#{author.email})+AND+status:merged+AND+after:#{I18n.localize(DateTime.now - 7, format: "%Y-%m-%d")}+AND+before:#{I18n.localize(DateTime.now, format: "%Y-%m-%d")}>last week commits</a>"
               %td= "<a href=https://chromium-review.googlesource.com/q/status:merged+author:#{author.email}>gerrit</a>"
-              %td= "<a href=https://codereview.chromium.org/search?closed=2&owner=#{author.email}>rietveld</a>"
               %td= "<a href=https://chromium-review.googlesource.com/q/is:open+owner:#{author.email}>ongoing</a>"
               %td= I18n.localize(author.commits.first.try(:date), format: :long) rescue ""
               %td= I18n.localize(author.commits.last.try(:date), format: :long) rescue ""


### PR DESCRIPTION
Chromium stopped supporting rietveld gerrit. So, the link doesn't work now.
This commit removes the column in the Author page.

Instead this commit adds a last week commits.