### PR TITLE
Show the last week commits to # instead of the <last week commits> text

### DIFF
--- a/lib/git_stats/git_data/author.rb
+++ b/lib/git_stats/git_data/author.rb
@@ -12,6 +12,10 @@ module GitStats
         @commits ||= repo.commits.select { |commit| commit.author == self }
       end
 
+      def last_week_commits
+        @last_week_commits ||= repo.last_week_commits.select { |commit| commit.author == self }
+      end
+
       def changed_lines
         insertions + deletions
       end

--- a/lib/git_stats/git_data/repo.rb
+++ b/lib/git_stats/git_data/repo.rb
@@ -57,6 +57,18 @@ module GitStats
         end.sort_by! { |e| e.date }
       end
 
+      def last_week_commits
+        @last_week_commits ||= run_and_parse("git rev-list --pretty=format:'%H|%at|%ai|%aE' --since=#{I18n.localize(DateTime.now - 7, format: "%Y-%m-%d")} #{commit_range} #{tree_path} | grep -v commit").map do |commit_line|
+          Commit.new(
+              repo: self,
+              sha: commit_line[:sha],
+              stamp: commit_line[:stamp],
+              date: DateTime.parse(commit_line[:date]),
+              author: authors.first! { |a| a.email == commit_line[:author_email] }
+          )
+        end.sort_by! { |e| e.date }
+      end
+
       def commits_period
         commits.map(&:date).minmax
       end

--- a/templates/authors/_authors.haml
+++ b/templates/authors/_authors.haml
@@ -28,7 +28,7 @@
               %th= i+1
               %th= "#{author.name} &lt;#{author.email}&gt;"
               %td= "<a href=https://chromium.googlesource.com/chromium/src/+log/master?author=#{author.email}>#{author.commits.size}</a>"
-              %td= "<a href=https://chromium-review.googlesource.com/q/(owner:#{author.email})+AND+status:merged+AND+after:#{I18n.localize(DateTime.now - 7, format: "%Y-%m-%d")}+AND+before:#{I18n.localize(DateTime.now, format: "%Y-%m-%d")}>last week commits</a>"
+              %td= "<a href=https://chromium-review.googlesource.com/q/(owner:#{author.email})+AND+status:merged+AND+after:#{I18n.localize(DateTime.now - 7, format: "%Y-%m-%d")}+AND+before:#{I18n.localize(DateTime.now, format: "%Y-%m-%d")}>#{author.last_week_commits.size}</a>"
               %td= "<a href=https://chromium-review.googlesource.com/q/status:merged+author:#{author.email}>gerrit</a>"
               %td= "<a href=https://chromium-review.googlesource.com/q/is:open+owner:#{author.email}>ongoing</a>"
               %td= I18n.localize(author.commits.first.try(:date), format: :long) rescue ""


### PR DESCRIPTION
This PR replaces the text of "last week commits" with the number
of the last week commits in order to know each author's last
week commits activity easily.